### PR TITLE
qiita_cloneのセキュリティグループをterraformでコード化

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -1,102 +1,10 @@
 resource "aws_security_group" "qiita_clone_2019_sg" {
   name        = "qiita_clone_2019_sg"
   description = "qiita_clone_2019_sg"
-
-  egress = [
-    {
-      cidr_blocks = [
-        "0.0.0.0/0",
-      ]
-      description      = ""
-      from_port        = 0
-      ipv6_cidr_blocks = []
-      prefix_list_ids  = []
-      protocol         = "-1"
-      security_groups  = []
-      self             = false
-      to_port          = 0
-    },
-  ]
-  ingress = [
-    {
-      cidr_blocks = [
-        "0.0.0.0/0",
-      ]
-      description = ""
-      from_port   = 3000
-      ipv6_cidr_blocks = [
-        "::/0",
-      ]
-      prefix_list_ids = []
-      protocol        = "tcp"
-      security_groups = []
-      self            = false
-      to_port         = 3000
-    },
-    {
-      cidr_blocks = [
-        "0.0.0.0/0",
-      ]
-      description = ""
-      from_port   = 80
-      ipv6_cidr_blocks = [
-        "::/0",
-      ]
-      prefix_list_ids = []
-      protocol        = "tcp"
-      security_groups = []
-      self            = false
-      to_port         = 80
-    },
-    {
-      cidr_blocks = [
-        "27.83.59.109/32",
-        "0.0.0.0/0",
-      ]
-      description      = ""
-      from_port        = 22
-      ipv6_cidr_blocks = []
-      prefix_list_ids  = []
-      protocol         = "tcp"
-      security_groups  = []
-      self             = false
-      to_port          = 22
-    },
-  ]
   vpc_id = "${aws_vpc.qiita_clone_2019_vpc.id}"
 }
 
 resource "aws_security_group" "qiita_clone_2019_rds_security_group" {
   description = "qiita_clone_2019_rds_security_group"
-  egress = [
-    {
-      cidr_blocks = [
-        "0.0.0.0/0",
-      ]
-      description      = ""
-      from_port        = 0
-      ipv6_cidr_blocks = []
-      prefix_list_ids  = []
-      protocol         = "-1"
-      security_groups  = []
-      self             = false
-      to_port          = 0
-    },
-  ]
-  ingress = [
-    {
-      cidr_blocks = [
-        "0.0.0.0/0",
-      ]
-      description      = ""
-      from_port        = 3306
-      ipv6_cidr_blocks = []
-      prefix_list_ids  = []
-      protocol         = "tcp"
-      security_groups  = []
-      self             = false
-      to_port          = 3306
-    },
-  ]
   vpc_id = "${aws_vpc.qiita_clone_2019_vpc.id}"
 }

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,0 +1,102 @@
+resource "aws_security_group" "qiita_clone_2019_sg" {
+  name        = "qiita_clone_2019_sg"
+  description = "qiita_clone_2019_sg"
+
+  egress = [
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description      = ""
+      from_port        = 0
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "-1"
+      security_groups  = []
+      self             = false
+      to_port          = 0
+    },
+  ]
+  ingress = [
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description = ""
+      from_port   = 3000
+      ipv6_cidr_blocks = [
+        "::/0",
+      ]
+      prefix_list_ids = []
+      protocol        = "tcp"
+      security_groups = []
+      self            = false
+      to_port         = 3000
+    },
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description = ""
+      from_port   = 80
+      ipv6_cidr_blocks = [
+        "::/0",
+      ]
+      prefix_list_ids = []
+      protocol        = "tcp"
+      security_groups = []
+      self            = false
+      to_port         = 80
+    },
+    {
+      cidr_blocks = [
+        "27.83.59.109/32",
+        "0.0.0.0/0",
+      ]
+      description      = ""
+      from_port        = 22
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "tcp"
+      security_groups  = []
+      self             = false
+      to_port          = 22
+    },
+  ]
+  vpc_id = "${aws_vpc.qiita_clone_2019_vpc.id}"
+}
+
+resource "aws_security_group" "qiita_clone_2019_rds_security_group" {
+  description = "qiita_clone_2019_rds_security_group"
+  egress = [
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description      = ""
+      from_port        = 0
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "-1"
+      security_groups  = []
+      self             = false
+      to_port          = 0
+    },
+  ]
+  ingress = [
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description      = ""
+      from_port        = 3306
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "tcp"
+      security_groups  = []
+      self             = false
+      to_port          = 3306
+    },
+  ]
+  vpc_id = "${aws_vpc.qiita_clone_2019_vpc.id}"
+}

--- a/security_group_rule.tf
+++ b/security_group_rule.tf
@@ -1,0 +1,112 @@
+resource "aws_security_group_rule" "qiita_clone_2019_sg_outbound_rule" {
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port         = 0
+  ipv6_cidr_blocks  = []
+  prefix_list_ids   = []
+  protocol          = "-1"
+  security_group_id = "${aws_security_group.qiita_clone_2019_sg.id}"
+  self              = false
+  to_port           = 0
+  type              = "egress"
+}
+
+resource "aws_security_group_rule" "qiita_clone_2019_sg_inbound_role_for_http" {
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port         = 80
+  ipv6_cidr_blocks  = []
+  prefix_list_ids   = []
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.qiita_clone_2019_sg.id}"
+  self              = false
+  to_port           = 80
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "qiita_clone_2019_sg_inbound_role_for_http_of_ipv6" {
+  cidr_blocks = []
+  from_port   = 80
+  ipv6_cidr_blocks = [
+    "::/0"
+  ]
+  prefix_list_ids   = []
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.qiita_clone_2019_sg.id}"
+  self              = false
+  to_port           = 80
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "qiita_clone_2019_sg_inbound_role_for_ssh" {
+  cidr_blocks = [
+    "27.83.59.109/32",
+    "0.0.0.0/0",
+  ]
+  from_port         = 22
+  ipv6_cidr_blocks  = []
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.qiita_clone_2019_sg.id}"
+  self              = false
+  to_port           = 22
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "qiita_clone_2019_sg_inbound_rule_for_application_server" {
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port         = 3000
+  ipv6_cidr_blocks  = []
+  prefix_list_ids   = []
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.qiita_clone_2019_sg.id}"
+  self              = false
+  to_port           = 3000
+  type              = "ingress"
+}
+
+resource "aws_security_group_rule" "qiita_clone_2019_sg_inbound_rule_for_application_server_of_ipv6" {
+  cidr_blocks = []
+  from_port   = 3000
+  ipv6_cidr_blocks = [
+    "::/0"
+  ]
+  prefix_list_ids   = []
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.qiita_clone_2019_sg.id}"
+  self              = false
+  to_port           = 3000
+  type              = "ingress"
+}
+
+
+
+resource "aws_security_group_rule" "qiita_clone_2019_rds_security_group_outbound_rule" {
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port         = 0
+  ipv6_cidr_blocks  = []
+  prefix_list_ids   = []
+  protocol          = "-1"
+  security_group_id = "${aws_security_group.qiita_clone_2019_rds_security_group.id}"
+  self              = false
+  to_port           = 0
+  type              = "egress"
+}
+resource "aws_security_group_rule" "qiita_clone_2019_rds_security_group_inbound_rule_for_mysql" {
+  cidr_blocks = [
+    "0.0.0.0/0"
+  ]
+  from_port         = 3306
+  ipv6_cidr_blocks  = []
+  prefix_list_ids   = []
+  protocol          = "tcp"
+  security_group_id = "${aws_security_group.qiita_clone_2019_rds_security_group.id}"
+  self              = false
+  to_port           = 3306
+  type              = "ingress"
+}


### PR DESCRIPTION
## Purpose
qiita_cloneのセキュリティグループをterraformでコード化

## Issue
#11 

## References
- [Resource: aws_security_group](https://www.terraform.io/docs/providers/aws/r/security_group.html)
- [Resource: aws_security_group_rule](https://www.terraform.io/docs/providers/aws/r/security_group_rule.html)

### Point of Review

https://github.com/yuta-ushijima/qiita_clone_2019_terraform/pull/12#discussion_r314984798

上記のように`aws_security_group `の中にingressの内容を記述する、いわゆるインライン的な書き方を推奨する派としない派で別れているため、プロジェクトによって方針が異なるかもしれません。


今回はsecurity_group_ruleを使って対応しました。`security_group_rule.tf`内で`security_group`のidを参照しています。

```
security_group_id = "${aws_security_group.qiita_clone_2019_sg.id}"
```

#### インライン的な書き方を推奨しない派(=security_group_ruleによる外部ルールとしてインバウンドとアウトバウンドを定義する)
https://qiita.com/sonots/items/a7604dfb10e9ca348fe1

#### インライン的な書き方を推奨する派
http://cavaliercoder.com/blog/inline-vs-discrete-security-groups-in-terraform.html