### PR TITLE
qiita_cloneのALBをterraformでコード化する

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,0 +1,21 @@
+resource "aws_lb" "qiita-clone-2019-elb" {
+  name               = "qiita-clone-2019-elb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups = [
+    "${aws_security_group.qiita_clone_2019_sg.id}"
+  ]
+  subnets = [
+    "${aws_subnet.qiita_clone_2019_public_subnet.id}",
+    "${aws_subnet.qiita_clone_2019_rds_subnet.id}"
+  ]
+
+  enable_http2 = true
+
+  enable_deletion_protection = false
+
+  idle_timeout = 60
+
+  ip_address_type = "ipv4"
+
+}


### PR DESCRIPTION
## Purpose
qiita_cloneのALBをterraformでコード化する

## Issue
#13 

## References
- [Resource: aws_lb](https://www.terraform.io/docs/providers/aws/r/lb.html)
- [TerraformでALBを構築する](https://dev.classmethod.jp/cloud/aws/terraform-alb/)
- [TerraformでAWSの構成を読み取るぞ（Terraform import)](https://qiita.com/miwato/items/88454ebd8d029ce02299)